### PR TITLE
Propagating the fitstatus from the minimizer directly

### DIFF
--- a/interface/CascadeMinimizer.h
+++ b/interface/CascadeMinimizer.h
@@ -38,6 +38,7 @@ class CascadeMinimizer {
         void setAutoMax(const RooArgSet *pois) ; 
 	double tolerance() {return defaultMinimizerTolerance_;};
 	std::string algo() {return defaultMinimizerAlgo_;};
+        int status() {return fStatus_;};
     private:
         RooAbsReal & nll_;
         std::auto_ptr<RooMinimizer> minimizer_;
@@ -97,6 +98,7 @@ class CascadeMinimizer {
 	static std::string defaultMinimizerAlgo_;
 	static double 	   defaultMinimizerTolerance_;
 	//static int 	   defaultMinimizerStrategy_;
+        static int fStatus_;
 
     	static bool runShortCombinations; 
         //static void setDefaultIntegrator(RooCategory &cat, const std::string & val) ;

--- a/interface/FitterAlgoBase.h
+++ b/interface/FitterAlgoBase.h
@@ -60,6 +60,7 @@ protected:
   /// If ndim > 1, errors on each parameter are from a n-dim chisquare, as for a joint estimation of N parameters 
   RooFitResult *doFit(RooAbsPdf &pdf, RooAbsData &data, RooRealVar &r,  const RooCmdArg &constrain, bool doHesse=true, int ndim=1,bool reuseNLL=false, bool saveFitResult=true) ;
   RooFitResult *doFit(RooAbsPdf &pdf, RooAbsData &data, const RooArgList &rs, const RooCmdArg &constrain, bool doHesse=true, int ndim=1,bool reuseNLL=false, bool saveFitResult=true) ;
+  RooFitResult *doFit(RooAbsPdf &pdf, RooAbsData &data, const RooArgList &rs, const RooCmdArg &constrain, int &status, bool doHesse=true, int ndim=1,bool reuseNLL=false, bool saveFitResult=true) ;
   double findCrossing(CascadeMinimizer &minim, RooAbsReal &nll, RooRealVar &r, double level, double rStart, double rBound) ;
   double findCrossingNew(CascadeMinimizer &minim, RooAbsReal &nll, RooRealVar &r, double level, double rStart, double rBound) ;
 

--- a/src/CascadeMinimizer.cc
+++ b/src/CascadeMinimizer.cc
@@ -35,6 +35,7 @@ std::string CascadeMinimizer::defaultMinimizerType_="Minuit2"; // default to min
 std::string CascadeMinimizer::defaultMinimizerAlgo_=ROOT::Math::MinimizerOptions::DefaultMinimizerAlgo();
 double CascadeMinimizer::defaultMinimizerTolerance_=1e-1;  
 int  CascadeMinimizer::strategy_=1; 
+int CascadeMinimizer::fStatus_=-999;
 
 std::map<std::string,std::vector<std::string> > const CascadeMinimizer::minimizerAlgoMap_{
  {"Minuit"	 ,{"Migrad","Simplex","Combined","Scan"}}
@@ -172,6 +173,7 @@ bool CascadeMinimizer::improveOnce(int verbose, bool noHesse)
             minimizer_->setPrintLevel(verbose-1); 
     	    if (verbose+2>0 ) Logger::instance().log(std::string(Form("CascadeMinimizer.cc: %d -- Hesse finished with status=%d",__LINE__,status)),Logger::kLogLevelDebug,__func__);
         }
+        fStatus_ = status;
         if (simnll) simnll->clearZeroPoint();
         outcome = (status == 0 || status == 1);
 	if (status==1) std::cerr << "[WARNING] Minimisation finished with status 1 (covariance forced positive definite), this could indicate a problem with the minimim!" << std::endl;

--- a/src/FitDiagnostics.cc
+++ b/src/FitDiagnostics.cc
@@ -251,12 +251,12 @@ bool FitDiagnostics::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, R
     // skip b-only fit
   } else if (minos_ != "all") {
     RooArgList minos; 
-    res_b = doFit(*mc_s->GetPdf(), data, minos, constCmdArg_s, /*hesse=*/true,/*ndim*/1,/*reuseNLL*/ true); 
+    res_b = doFit(*mc_s->GetPdf(), data, minos, constCmdArg_s, fitStatus_, /*hesse=*/true,/*ndim*/1,/*reuseNLL*/ true); 
     nll_bonly_=nll->getVal()-nll0;   
   } else {
     CloseCoutSentry sentry(verbose < 2);
     RooArgList minos = (*mc_s->GetNuisanceParameters()); 
-    res_b = doFit(*mc_s->GetPdf(), data, minos, constCmdArg_s, /*hesse=*/true,/*ndim*/1,/*reuseNLL*/ true); 
+    res_b = doFit(*mc_s->GetPdf(), data, minos, constCmdArg_s, fitStatus_, /*hesse=*/true,/*ndim*/1,/*reuseNLL*/ true); 
 
     if (res_b) nll_bonly_ = nll->getVal() - nll0;
 
@@ -270,7 +270,6 @@ bool FitDiagnostics::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, R
            //		setFitResultTrees(mc_s->GetNuisanceParameters(),nuisanceParameters_);
            // setFitResultTrees(mc_s->GetGlobalObservables(),globalObservables_);
 	 }
-	 fitStatus_ = res_b->status();
       }
       numbadnll_=res_b->numInvalidNLL();
          
@@ -334,13 +333,13 @@ bool FitDiagnostics::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, R
   r->setVal(preFitValue_); r->setConstant(false); 
   if (minos_ != "all") {
     RooArgList minos; if (minos_ == "poi") minos.add(*r);
-    res_s = doFit(*mc_s->GetPdf(), data, minos, constCmdArg_s, /*hesse=*/!noErrors_,/*ndim*/1,/*reuseNLL*/ true); 
+    res_s = doFit(*mc_s->GetPdf(), data, minos, constCmdArg_s, fitStatus_, /*hesse=*/!noErrors_,/*ndim*/1,/*reuseNLL*/ true); 
     nll_sb_ = nll->getVal()-nll0;
   } else {
     CloseCoutSentry sentry(verbose < 2);
     RooArgList minos = (*mc_s->GetNuisanceParameters()); 
     minos.add((*mc_s->GetParametersOfInterest()));  // Add POI this time 
-    res_s = doFit(*mc_s->GetPdf(), data, minos, constCmdArg_s, /*hesse=*/true,/*ndim*/1,/*reuseNLL*/ true); 
+    res_s = doFit(*mc_s->GetPdf(), data, minos, constCmdArg_s, fitStatus_, /*hesse=*/true,/*ndim*/1,/*reuseNLL*/ true); 
     if (res_s) nll_sb_= nll->getVal()-nll0;
 
   }
@@ -356,7 +355,6 @@ bool FitDiagnostics::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, R
            //	   setFitResultTrees(mc_s->GetNuisanceParameters(),nuisanceParameters_);
 	   //setFitResultTrees(mc_s->GetGlobalObservables(),globalObservables_);
 	 }
-	 fitStatus_ = res_s->status();
          numbadnll_ = res_s->numInvalidNLL();
 
          if ( verbose > 0 ) Logger::instance().log(std::string(Form("FitDiagnostics.cc: %d -- Fit S+B, status = %d, numBadNLL = %d, covariance quality = %d",__LINE__,fitStatus_,numbadnll_,res_s->covQual())),Logger::kLogLevelDebug,__func__);

--- a/src/FitDiagnostics.cc
+++ b/src/FitDiagnostics.cc
@@ -965,7 +965,6 @@ void FitDiagnostics::setNormsFitResultTrees(const RooArgSet *args, double * vals
 	 
          for (TObject *a = iter->Next(); a != 0; a = iter->Next()) { 
                  RooRealVar *rcv = dynamic_cast<RooRealVar *>(a);   
-                 std::cout << "index " << count << ", Name " << rcv->GetName() << ", val " <<  rcv->getVal() << std::endl;
 		 std::string name = rcv->GetName();
 		 vals[count]=rcv->getVal();
 		 count++;

--- a/src/FitterAlgoBase.cc
+++ b/src/FitterAlgoBase.cc
@@ -207,6 +207,11 @@ RooFitResult *FitterAlgoBase::doFit(RooAbsPdf &pdf, RooAbsData &data, RooRealVar
 }
 
 RooFitResult *FitterAlgoBase::doFit(RooAbsPdf &pdf, RooAbsData &data, const RooArgList &rs, const RooCmdArg &constrain, bool doHesse, int ndim, bool reuseNLL, bool saveFitResult) {
+  int status = 0;
+  return doFit(pdf, data, rs, constrain, status, doHesse, ndim, reuseNLL, saveFitResult);
+}
+
+RooFitResult *FitterAlgoBase::doFit(RooAbsPdf &pdf, RooAbsData &data, const RooArgList &rs, const RooCmdArg &constrain, int &status, bool doHesse, int ndim, bool reuseNLL, bool saveFitResult) {
     RooFitResult *ret = 0;
     if (reuseNLL && nll.get() != 0 && !forceRecreateNLL_) {
         ((cacheutils::CachingSimNLL&)(*nll)).setData(data); // reuse nll but swap out the data
@@ -238,6 +243,8 @@ RooFitResult *FitterAlgoBase::doFit(RooAbsPdf &pdf, RooAbsData &data, const RooA
     sentry.clear();
     ret = (saveFitResult || rs.getSize() ? minim.save() : new RooFitResult("dummy","success"));
     if (verbose > 1 && ret != 0 && (saveFitResult || rs.getSize())) { ret->Print("V");  }
+
+    status = minim.status();
 
     std::auto_ptr<RooArgSet> allpars(pdf.getParameters(data));
     RooArgSet* bestFitPars = (RooArgSet*)allpars->snapshot() ;
@@ -362,7 +369,7 @@ RooFitResult *FitterAlgoBase::doFit(RooAbsPdf &pdf, RooAbsData &data, const RooA
             }
 
             r.setVal(r0); r.setConstant(false);
-        }
+       }
     }
 
     *allpars = *bestFitPars;

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -164,12 +164,13 @@ bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooS
     if (nConstPoi>0) std::cout << "Following POIs have been set constant (use --floatOtherPOIs to let them float): " << setConstPOI << std::endl;
  
     // start with a best fit
+    int status=-999;
     const RooCmdArg &constrainCmdArg = withSystematics  ? RooFit::Constrain(*mc_s->GetNuisanceParameters()) : RooCmdArg();
     std::auto_ptr<RooFitResult> res;
     if (verbose <= 3) RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CountErrors);
     bool doHesse = (algo_ == Singles || algo_ == Impact) || (saveFitResult_) ;
     if ( !skipInitialFit_){
-        res.reset(doFit(pdf, data, (doHesse ? poiList_ : RooArgList()), constrainCmdArg, false, 1, true, false));
+      res.reset(doFit(pdf, data, (doHesse ? poiList_ : RooArgList()), constrainCmdArg, status, false, 1, true, false));
         if (!res.get()) {
             std::cout << "\n " <<std::endl;
             std::cout << "\n ---------------------------" <<std::endl;
@@ -213,7 +214,7 @@ bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooS
 		specifiedCatVals_[j]=specifiedCat_[j]->getIndex();
 	}
         covQual_ = res->covQual();
-        fitStatus_ = res->status();
+        fitStatus_ = status;
 	Combine::commitPoint(/*expected=*/false, /*quantile=*/-1.); // Combine will not commit a point anymore at -1 so can do it here 
 	//}
     }


### PR DESCRIPTION
@bendavid For some reason the fit status in the case of the BGFS2 minimizer is not saved in the RooFitResult. 
In combined I propagated it directly from the minimizer, in the cases of:
- MultiDimFit (used by the scans)
- FitDiagnostics (used by toys)

@mdunser @cippy 