### PR TITLE
Bin-by-bin statistical uncertainties by Josh

### DIFF
--- a/python/tfscipyhess.py
+++ b/python/tfscipyhess.py
@@ -65,7 +65,7 @@ def jacobian(ys,
   gradient = array_ops.reshape(gradient, [-1])
 
   # Declare an iterator and tensor array loop variables for the gradients.
-  n = array_ops.size(x)
+  n = array_ops.size(gradient)
   loop_vars = [
       array_ops.constant(0, dtypes.int32),
       tensor_array_ops.TensorArray(x.dtype, n)
@@ -81,9 +81,10 @@ def jacobian(ys,
       back_prop = back_prop,
   )
 
+  _shapey = array_ops.shape(ys)
   _shape = array_ops.shape(x)
   _reshaped_hessian = array_ops.reshape(hessian.stack(),
-                                        array_ops.concat((_shape, _shape), 0))
+                                        array_ops.concat((_shapey, _shape), 0))
   #hessians.append(_reshaped_hessian)
   return _reshaped_hessian
 

--- a/scripts/combinetf.py
+++ b/scripts/combinetf.py
@@ -297,7 +297,7 @@ if options.binByBinStat:
     #TODO: Currently modification of yields from bin-by-bin uncertainties is
     #uniformly distributed over all processes, consider a more fine-grained breakdown based
     #on "full" version of bin-by-bin stat uncertainties
-    normfull = tf.reshape(betafull,[-1,1])*normfullnom
+    normfull = tf.reshape(betafull,[-1,1])*normfullcentral
 else:
   nexp = nexpcentral
   nexpgen = nexpcentral

--- a/scripts/combinetf.py
+++ b/scripts/combinetf.py
@@ -315,6 +315,9 @@ pmaskedexpnorm = r*pmaskedexpnorm
 
   
 if options.saveHists:
+  nexpsigcentral = tf.reduce_sum(normfullcentral[:,:nsignals],axis=-1)
+  nexpbkgcentral = tf.reduce_sum(normfullcentral[:,nsignals:],axis=-1)
+  
   nexpsig = tf.reduce_sum(normfull[:,:nsignals],axis=-1)
   nexpbkg = tf.reduce_sum(normfull[:,nsignals:],axis=-1)
 
@@ -442,10 +445,10 @@ if options.saveHists:
   invhessianchol = tf.cholesky(invhessian)
   
   #compute uncertainties for expectations (prefit)
-  normfullerrpre = experr(normfull,invhessianprefitchol)
-  nexpfullerrpre = experr(nexpfull,invhessianprefitchol)
-  nexpsigerrpre = experr(nexpsig, invhessianprefitchol)
-  nexpbkgerrpre = experr(nexpbkg, invhessianprefitchol)
+  normfullerrpre = experr(normfullcentral,invhessianprefitchol)
+  nexpfullerrpre = experr(nexpfullcentral,invhessianprefitchol)
+  nexpsigerrpre = experr(nexpsigcentral, invhessianprefitchol)
+  nexpbkgerrpre = experr(nexpbkgcentral, invhessianprefitchol)
   
   ##compute uncertainties for expectations (postfit, using the full covariance matrix)
   normfullerr = experr(normfull,invhessianchol)
@@ -658,9 +661,9 @@ def fillHists(tag, witherrors=options.computeHistErrors):
   
   if tag=='prefit':
     if witherrors:
-      normfullval, nexpfullval, nexpsigval, nexpbkgval, nexpfullerrval, nexpsigerrval, nexpbkgerrval, normfullerrval = sess.run([normfull,nexpfull,nexpsig,nexpbkg,nexpfullerrpre,nexpsigerrpre,nexpbkgerrpre,normfullerrpre])
+      normfullval, nexpfullval, nexpsigval, nexpbkgval, nexpfullerrval, nexpsigerrval, nexpbkgerrval, normfullerrval = sess.run([normfullcentral,nexpfullcentral,nexpsigcentral,nexpbkgcentral,nexpfullerrpre,nexpsigerrpre,nexpbkgerrpre,normfullerrpre])
     else:
-      normfullval, nexpfullval, nexpsigval, nexpbkgval, nexpfullerrval, nexpsigerrval, nexpbkgerrval, normfullerrval = sess.run([normfull,nexpfull,nexpsig,nexpbkg]) + [None,None,None,None]
+      normfullval, nexpfullval, nexpsigval, nexpbkgval, nexpfullerrval, nexpsigerrval, nexpbkgerrval, normfullerrval = sess.run([normfullcentral,nexpfullcentral,nexpsigcentral,nexpbkgcentral]) + [None,None,None,None]
   else:
     if witherrors:
       normfullval, nexpfullval, nexpsigval, nexpbkgval, nexpfullerrval, nexpsigerrval, nexpbkgerrval, normfullerrval = sess.run([normfull,nexpfull,nexpsig,nexpbkg,nexpfullerr,nexpsigerr,nexpbkgerr,normfullerr])


### PR DESCRIPTION
Hi,
Bin-by-bin statistical uncertainties are now available in the main
"tensorflowfit" branch as usual.

https://github.com/bendavid/HiggsAnalysis-CombinedLimit/tree/tensorflowfit

To use this, hdf5 files will need to be regenerated since some
additional info is added there to keep track of the statistical
uncertainty per bin. (but this is automatic and no new options are
needed)

There are two new options in combinetf

parser.add_option("","--binByBinStat", default=False,
action='store_true', help="add bin-by-bin statistical uncertainties on
templates (using Barlow and Beeston 'lite' method")

parser.add_option("","--correlateXsecStat", default=False,
action='store_true', help="Assume that cross sections in masked
channels are correlated with expected values in templates (ie computed
from the same MC events)")

The second option exploits partial statistical correlation when
computing cross sections, so the effect of the bin-by-bin
uncertainties on cross sections is somewhat reduced.  Using this
option requires that the cards adopt the new normalization convention
for the masked channels (xsec*nominal lumi instead of xsec).  I added
a --scaleMaskedYields to text2hdf5.py to allow doing this by hand for
the moment on existing cards.

So you would either run
combinetf.py card.hdf5 -t -1 --binByBinStat

or
combinetf.py card.hdf5 -t -1 --binByBinStat --correlateXsecStat

Using --byByBinStat alone does not require the new normalization convention.

Uncertainties are fully consistently propagated for hessian (also to
the covariance matrices), likelihood scans, minos.

For toys, even though our default is to treat nuisance parameters in a
frequentist way (randomize constraint minima, keep generating values
fixed), the bin-by-bin stat uncertainties are instead always handled
in a bayesian way (keep constarint minima fixed, randomize generating
values)

This should be ok for expected results, but it means that they cannot
currently be consistently propagated to bootstrap toys on data (and
the code will fail with an error if you try to do it)

The fully correct frequentist treatment requires some additional math
which I'll work out in the next few days, but what is there now should
be fully sufficient for expected results, also with toys if needed.

The bin-by-bin uncertainties should also be propagated to the postfit
histograms and their uncertainties.  (but currently not to the prefit
histograms)

Please test as needed and let me know if there are any issues as usual.

Thanks,
Josh