### PR TITLE
Expanded combinetf outputs

### DIFF
--- a/python/Datacard.py
+++ b/python/Datacard.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 class Datacard():
     """
     Description:
@@ -50,6 +52,8 @@ class Datacard():
         
 	self.groups = {}
 	self.discretes = []
+	
+	self.chargeGroups = OrderedDict()
 
     def print_structure(self):
 	"""
@@ -94,6 +98,7 @@ MB = None
   	print "DC.binParFlags 	= "	  	, self.binParFlags        	,"#",type(self.binParFlags)	
 	print "DC.groups 	= "		, self.groups        		,"#",type(self.groups)	
 	print "DC.discretes 	= "		, self.discretes        	,"#",type(self.discretes)	
+	print "DC.chargeGroups 	= "		, self.chargeGroups        	,"#",type(self.chargeGroups)	
 
 	print """
 

--- a/python/Datacard.py
+++ b/python/Datacard.py
@@ -54,6 +54,9 @@ class Datacard():
 	self.discretes = []
 	
 	self.chargeGroups = OrderedDict()
+	self.polGroups = OrderedDict()
+	self.sumGroups = OrderedDict()
+	self.chargeMetaGroups = OrderedDict()
 
     def print_structure(self):
 	"""
@@ -99,6 +102,9 @@ MB = None
 	print "DC.groups 	= "		, self.groups        		,"#",type(self.groups)	
 	print "DC.discretes 	= "		, self.discretes        	,"#",type(self.discretes)	
 	print "DC.chargeGroups 	= "		, self.chargeGroups        	,"#",type(self.chargeGroups)	
+	print "DC.polGroups 	= "		, self.polGroups        	,"#",type(self.polGroups)	
+	print "DC.sumGroups 	= "		, self.sumGroups        	,"#",type(self.sumGroups)	
+	print "DC.chargeMetaGroups 	= "		, self.chargeMetaGroups        	,"#",type(self.chargeMetaGroups)	
 
 	print """
 

--- a/python/DatacardParser.py
+++ b/python/DatacardParser.py
@@ -267,18 +267,77 @@ def parseCard(file, options):
                 if not groupProcs:
                     raise RuntimeError, "Syntax error for group '%s': empty line after 'group'." % groupName
 
-                defToks = ('=')
                 defTok = groupProcs.pop(0)
-                if defTok not in defToks:
+                if defTok!='=':
                     raise RuntimeError, "Syntax error for chargeGroup '%s': first thing after 'chargeGroup' is not '=' but '%s'." % (groupName,defTok)
 
+                if len(groupProcs) != 2:
+                    raise RuntimeError, "Error for chargeGroup '%s': group has %d elements, but expected to have 2." % len(groupProcs)
+
                 if groupName not in ret.chargeGroups:
-                    if defTok=='=':
-                        ret.chargeGroups[groupName] = list(groupProcs)
-                    else:
-                        raise RuntimeError, "Cannot append to group '%s' as it was not yet defined." % groupName
+                    ret.chargeGroups[groupName] = list(groupProcs)
                 else:
                     raise RuntimeError, "Will not redefine group '%s'. It previously contained '%s' and you now wanted it to contain '%s'." % (groupName,ret.chargeGroups[groupName],groupProcs)
+
+                continue
+            elif pdf=="polGroup":
+                # This is not really a pdf type, but a way to be able to group processes together
+                groupName = lsyst
+                groupProcs = numbers
+
+                if not groupProcs:
+                    raise RuntimeError, "Syntax error for group '%s': empty line after 'group'." % groupName
+
+                defTok = groupProcs.pop(0)
+                if defTok!='=':
+                    raise RuntimeError, "Syntax error for polGroup '%s': first thing after 'polGroup' is not '=' but '%s'." % (groupName,defTok)
+
+                if len(groupProcs) != 3:
+                    raise RuntimeError, "Error for polGroup '%s': group has %d elements, but expected to have 3." % len(groupProcs)
+
+                if groupName not in ret.polGroups:
+                    ret.polGroups[groupName] = list(groupProcs)
+                else:
+                    raise RuntimeError, "Will not redefine group '%s'. It previously contained '%s' and you now wanted it to contain '%s'." % (groupName,ret.polGroups[groupName],groupProcs)
+
+                continue
+            elif pdf=="sumGroup":
+                # This is not really a pdf type, but a way to be able to group processes together
+                groupName = lsyst
+                groupProcs = numbers
+
+                if not groupProcs:
+                    raise RuntimeError, "Syntax error for group '%s': empty line after 'group'." % groupName
+
+                defTok = groupProcs.pop(0)
+                if defTok!='=':
+                    raise RuntimeError, "Syntax error for sumGroup '%s': first thing after 'sumGroup' is not '=' but '%s'." % (groupName,defTok)
+
+                if groupName not in ret.sumGroups:
+                    ret.sumGroups[groupName] = list(groupProcs)
+                else:
+                    raise RuntimeError, "Will not redefine group '%s'. It previously contained '%s' and you now wanted it to contain '%s'." % (groupName,ret.sumGroups[groupName],groupProcs)
+
+                continue              
+            elif pdf=="chargeMetaGroup":
+                # This is not really a pdf type, but a way to be able to group processes together
+                groupName = lsyst
+                groupProcs = numbers
+
+                if not groupProcs:
+                    raise RuntimeError, "Syntax error for group '%s': empty line after 'group'." % groupName
+
+                defTok = groupProcs.pop(0)
+                if defTok!='=':
+                    raise RuntimeError, "Syntax error for chargeMetaGroup '%s': first thing after 'chargeMetaGroup' is not '=' but '%s'." % (groupName,defTok)
+
+                if len(groupProcs) != 2:
+                    raise RuntimeError, "Error for chargeMetaGroup '%s': group has %d elements, but expected to have 2." % len(groupProcs)
+
+                if groupName not in ret.chargeMetaGroups:
+                    ret.chargeMetaGroups[groupName] = list(groupProcs)
+                else:
+                    raise RuntimeError, "Will not redefine group '%s'. It previously contained '%s' and you now wanted it to contain '%s'." % (groupName,ret.chargeMetaGroups[groupName],groupProcs)
 
                 continue
 	    elif pdf=="autoMCStats":

--- a/python/DatacardParser.py
+++ b/python/DatacardParser.py
@@ -256,6 +256,29 @@ def parseCard(file, options):
                         ret.groups[groupName].update( set(groupNuisances) )
                     else:
                         raise RuntimeError, "Will not redefine group '%s'. It previously contained '%s' and you now wanted it to contain '%s'." % (groupName,ret.groups[groupName],groupNuisances)
+                      
+                continue
+                      
+            elif pdf=="chargeGroup":
+                # This is not really a pdf type, but a way to be able to group processes together
+                groupName = lsyst
+                groupProcs = numbers
+
+                if not groupProcs:
+                    raise RuntimeError, "Syntax error for group '%s': empty line after 'group'." % groupName
+
+                defToks = ('=')
+                defTok = groupProcs.pop(0)
+                if defTok not in defToks:
+                    raise RuntimeError, "Syntax error for chargeGroup '%s': first thing after 'chargeGroup' is not '=' but '%s'." % (groupName,defTok)
+
+                if groupName not in ret.chargeGroups:
+                    if defTok=='=':
+                        ret.chargeGroups[groupName] = list(groupProcs)
+                    else:
+                        raise RuntimeError, "Cannot append to group '%s' as it was not yet defined." % groupName
+                else:
+                    raise RuntimeError, "Will not redefine group '%s'. It previously contained '%s' and you now wanted it to contain '%s'." % (groupName,ret.chargeGroups[groupName],groupProcs)
 
                 continue
 	    elif pdf=="autoMCStats":

--- a/scripts/combineCards.py
+++ b/scripts/combineCards.py
@@ -37,7 +37,8 @@ from HiggsAnalysis.CombinedLimit.DatacardParser import *
 obsline = []; obskeyline = [] ;
 keyline = []; expline = []; systlines = {}
 signals = []; backgrounds = []; shapeLines = []
-paramSysts = {}; flatParamNuisances = {}; discreteNuisances = {}; groups = {}; rateParams = {}; rateParamsOrder = set(); chargeGroups = collections.OrderedDict()
+paramSysts = {}; flatParamNuisances = {}; discreteNuisances = {}; groups = {}; rateParams = {}; rateParamsOrder = set()
+chargeGroups = collections.OrderedDict(); polGroups = collections.OrderedDict(); sumGroups = collections.OrderdDict(); chargeMetaGroups = collections.OrderedDict();
 extArgs = {}; binParFlags = {}
 nuisanceEdits = [];
 
@@ -184,7 +185,31 @@ for ich,fname in enumerate(args):
             else:
                 raise RuntimeError, "Conflicting definition of chargeGroup %s" % groupName
         else:
-            chargeGroups[groupName] = procNames            
+            chargeGroups[groupName] = procNames
+    for groupName,procNames in DC.polGroups.iteritems():
+        if groupName in polGroups:
+            if polGroups[groupName] == procNames:
+                continue
+            else:
+                raise RuntimeError, "Conflicting definition of polGroup %s" % groupName
+        else:
+            polGroups[groupName] = procNames
+    for groupName,procNames in DC.sumGroups.iteritems():
+        if groupName in sumGroups:
+            if sumGroups[groupName] == procNames:
+                continue
+            else:
+                raise RuntimeError, "Conflicting definition of sumGroup %s" % groupName
+        else:
+            sumGroups[groupName] = procNames
+    for groupName,procNames in DC.chargeMetaGroups.iteritems():
+        if groupName in chargeMetaGroups:
+            if chargeMetaGroups[groupName] == procNames:
+                continue
+            else:
+                raise RuntimeError, "Conflicting definition of chargeMetaGroup %s" % groupName
+        else:
+            chargeMetaGroups[groupName] = procNames
 
     # Finally report nuisance edits propagated to end of card
     for editline in DC.nuisanceEditLines:

--- a/scripts/combineCards.py
+++ b/scripts/combineCards.py
@@ -4,6 +4,7 @@ from sys import argv
 import os.path
 from pprint import pprint
 from optparse import OptionParser
+from collections import OrderdDict
 parser = OptionParser(
     usage="%prog [options] [label=datacard.txt | datacard.txt]",
     epilog="The label=datacard.txt syntax allows to specify the label that channels from datacard.txt will have in the combined datacard. To combine cards with different energies one can use dc_7TeV=datacard7.txt dc_8TeV=datacard8.txt (avoid using labels starting with numbers)."
@@ -36,7 +37,7 @@ from HiggsAnalysis.CombinedLimit.DatacardParser import *
 obsline = []; obskeyline = [] ;
 keyline = []; expline = []; systlines = {}
 signals = []; backgrounds = []; shapeLines = []
-paramSysts = {}; flatParamNuisances = {}; discreteNuisances = {}; groups = {}; rateParams = {}; rateParamsOrder = set();
+paramSysts = {}; flatParamNuisances = {}; discreteNuisances = {}; groups = {}; rateParams = {}; rateParamsOrder = set(); chargeGroups = collections.OrderedDict()
 extArgs = {}; binParFlags = {}
 nuisanceEdits = [];
 
@@ -175,6 +176,15 @@ for ich,fname in enumerate(args):
             groups[groupName].update(set(nuisanceNames))
         else:
             groups[groupName] = set(nuisanceNames)
+            
+    for groupName,procNames in DC.chargeGroups.iteritems():
+        if groupName in chargeGroups:
+            if chargeGroups[groupName] == procNames:
+                continue
+            else:
+                raise RuntimeError, "Conflicting definition of chargeGroup %s" % groupName
+        else:
+            chargeGroups[groupName] = procNames            
 
     # Finally report nuisance edits propagated to end of card
     for editline in DC.nuisanceEditLines:

--- a/scripts/combineCards.py
+++ b/scripts/combineCards.py
@@ -11,6 +11,7 @@ parser = OptionParser(
 parser.add_option("-s", "--stat",   dest="stat",          default=False, action="store_true", help="Drop all systematics")
 parser.add_option("-S", "--force-shape", dest="shape",    default=False, action="store_true", help="Treat all channels as shape analysis. Useful for mixed combinations")
 parser.add_option("-a", "--asimov", dest="asimov",  default=False, action="store_true", help="Replace observation with asimov dataset. Works only for counting experiments")
+parser.add_option(      "--noDirPrefix", dest="noDirPrefix",  default=False, action="store_true", help="Do not attempt to dirname of the orignal datacard to shapes file")
 parser.add_option("-P", "--prefix", type="string", dest="fprefix", default="",  help="Prefix this to all file names")
 parser.add_option("--xc", "--exclude-channel", type="string", dest="channelVetos", default=[], action="append", help="Exclude channels that match this regexp; can specify multiple ones")
 parser.add_option("--ic", "--include-channel", type="string", dest="channelIncludes", default=[], action="append", help="Only include channels that match this regexp; can specify multiple ones")
@@ -147,12 +148,12 @@ for ich,fname in enumerate(args):
             p2sMapD = DC.shapeMap['*'] if DC.shapeMap.has_key('*') else {}
             for p, x in p2sMap.items():
                 xrep = [xi.replace("$CHANNEL",b) for xi in x]
-                if xrep[0] != 'FAKE' and dirname != '': xrep[0] = dirname+"/"+xrep[0]
+                if xrep[0] != 'FAKE' and dirname != '' and not options.noDirPrefix: xrep[0] = dirname+"/"+xrep[0]
                 shapeLines.append((p,bout,xrep))
             for p, x in p2sMapD.items():
                 if p2sMap.has_key(p): continue
                 xrep = [xi.replace("$CHANNEL",b) for xi in x]
-                if xrep[0] != 'FAKE' and dirname != '': xrep[0] = dirname+"/"+xrep[0]
+                if xrep[0] != 'FAKE' and dirname != '' and not options.noDirPrefix: xrep[0] = dirname+"/"+xrep[0]
                 shapeLines.append((p,bout,xrep))
     elif options.shape:
         for b in DC.bins:

--- a/scripts/combinetf.py
+++ b/scripts/combinetf.py
@@ -38,6 +38,7 @@ from array import array
 from HiggsAnalysis.CombinedLimit.tfscipyhess import ScipyTROptimizerInterface,jacobian,sum_loop
 
 parser = OptionParser(usage="usage: %prog [options] datacard.txt -o output \nrun with --help to get list of options")
+parser.add_option("-o","--output", default=None, type="string", help="output file name")
 parser.add_option("-t","--toys", default=0, type=int, help="run a given number of toys, 0 fits the data (default), and -1 fits the asimov toy")
 parser.add_option("","--toysFrequentist", default=True, action='store_true', help="run frequentist-type toys by randomizing constraint minima")
 parser.add_option("","--bypassFrequentistFit", default=True, action='store_true', help="bypass fit to data when running frequentist toys to get toys based on prefit expectations")
@@ -574,7 +575,7 @@ if options.binByBinStat:
   bayesassignbeta = tf.assign(betagen, tf.random_gamma(shape=[],alpha=kstat+1.,beta=kstat,dtype=tf.as_dtype(dtype)))
 
 #initialize output tree
-f = ROOT.TFile( 'fitresults_%i.root' % seed, 'recreate' )
+f = ROOT.TFile(options.output if options.output else 'fitresults_%i.root' % seed, 'recreate' )
 tree = ROOT.TTree("fitresults", "fitresults")
 
 tseed = array('i', [seed])

--- a/scripts/text2hdf5.py
+++ b/scripts/text2hdf5.py
@@ -218,7 +218,14 @@ for chan in chans:
       if (norm_chan_hist.GetSumw2().GetSize()>0):
         print("proper uncertainties")
         sumw2_chan_hist = norm_chan_hist.Clone()
-        sumw2_chan_hist.Set(sumw2_chan_hist.GetSumw2().GetSize(), sumw2_chan_hist.GetSumw2().GetArray())
+        try:
+            sumw2_chan_hist.Set(sumw2_chan_hist.GetSumw2().GetSize(), sumw2_chan_hist.GetSumw2().GetArray())
+        except:
+            #in ROOT v6.12/07  set expects an array of floats not a TArrayD
+            from array import array
+            sumw2f=[sumw2_chan_hist.GetSumw2()[i] for i in range(sumw2_chan_hist.GetSumw2().GetSize())]
+            sumw2f = array('f',sumw2f)
+            sumw2_chan_hist.Set(sumw2_chan_hist.GetSumw2().GetSize(), sumw2f)
         sumw2_chan = hist2array(sumw2_chan_hist, include_overflow=False).astype(dtype)
         sumw2_chan_hist.Delete()
       else:

--- a/scripts/text2hdf5.py
+++ b/scripts/text2hdf5.py
@@ -59,6 +59,8 @@ else:
 ## Parse text file 
 DC = parseCard(file, options)
 
+print(DC.chargeGroups)
+
 if options.dumpCard:
     DC.print_structure()
     exit()
@@ -105,6 +107,16 @@ for group in DC.groups:
   for syst in DC.groups[group]:
     systgroupidx.append(systs.index(syst))
   systgroupidxs.append(systgroupidx)
+    
+#list of groups of signal processes by charge
+chargegroups = []
+chargegroupidxs = []
+for group in DC.chargeGroups:
+  chargegroups.append(group)
+  chargegroupidx = []
+  for proc in DC.chargeGroups[group]:
+    chargegroupidx.append(procs.index(proc))
+  chargegroupidxs.append(chargegroupidx)
     
 #list of channels, ordered such that masked channels are last
 chans = []
@@ -471,6 +483,12 @@ hsystgroups[...] = systgroups
 
 hsystgroupidxs = f.create_dataset("hsystgroupidxs", [len(systgroupidxs)], dtype=h5py.special_dtype(vlen=np.dtype('int32')), compression="gzip")
 hsystgroupidxs[...] = systgroupidxs
+
+hchargegroups = f.create_dataset("hchargegroups", [len(chargegroups)], dtype=h5py.special_dtype(vlen=str), compression="gzip")
+hchargegroups[...] = chargegroups
+
+hchargegroupidxs = f.create_dataset("hchargegroupidxs", [len(chargegroups),2], dtype='int32', compression="gzip")
+hchargegroupidxs[...] = chargegroupidxs
 
 hmaskedchans = f.create_dataset("hmaskedchans", [len(maskedchans)], dtype=h5py.special_dtype(vlen=str), compression="gzip")
 hmaskedchans[...] = maskedchans

--- a/scripts/text2hdf5.py
+++ b/scripts/text2hdf5.py
@@ -59,8 +59,6 @@ else:
 ## Parse text file 
 DC = parseCard(file, options)
 
-print(DC.chargeGroups)
-
 if options.dumpCard:
     DC.print_structure()
     exit()
@@ -117,6 +115,36 @@ for group in DC.chargeGroups:
   for proc in DC.chargeGroups[group]:
     chargegroupidx.append(procs.index(proc))
   chargegroupidxs.append(chargegroupidx)
+
+#list of groups of signal processes by polarization
+polgroups = []
+polgroupidxs = []
+for group in DC.polGroups:
+  polgroups.append(group)
+  polgroupidx = []
+  for proc in DC.polGroups[group]:
+    polgroupidx.append(procs.index(proc))
+  polgroupidxs.append(polgroupidx)
+  
+#list of groups of signal processes to be summed
+sumgroups = []
+sumgroupsegmentids = []
+sumgroupidxs = []
+for igroup,group in enumerate(DC.sumGroups):
+  sumgroups.append(group)
+  for proc in DC.sumGroups[group]:
+    sumgroupsegmentids.append(igroup)
+    sumgroupidxs.append(procs.index(proc))
+    
+#list of groups of signal processes by chargemeta
+chargemetagroups = []
+chargemetagroupidxs = []
+for group in DC.chargeMetaGroups:
+  chargemetagroups.append(group)
+  chargemetagroupidx = []
+  for proc in DC.chargeMetaGroups[group]:
+    chargemetagroupidx.append(sumgroups.index(proc))
+  chargemetagroupidxs.append(chargemetagroupidx)
     
 #list of channels, ordered such that masked channels are last
 chans = []
@@ -489,6 +517,27 @@ hchargegroups[...] = chargegroups
 
 hchargegroupidxs = f.create_dataset("hchargegroupidxs", [len(chargegroups),2], dtype='int32', compression="gzip")
 hchargegroupidxs[...] = chargegroupidxs
+
+hpolgroups = f.create_dataset("hpolgroups", [len(polgroups)], dtype=h5py.special_dtype(vlen=str), compression="gzip")
+hpolgroups[...] = polgroups
+
+hpolgroupidxs = f.create_dataset("hpolgroupidxs", [len(polgroups),3], dtype='int32', compression="gzip")
+hpolgroupidxs[...] = polgroupidxs
+
+hsumgroups = f.create_dataset("hsumgroups", [len(sumgroups)], dtype=h5py.special_dtype(vlen=str), compression="gzip")
+hsumgroups[...] = sumgroups
+
+hsumgroupsegmentids = f.create_dataset("hsumgroupsegmentids", [len(sumgroupsegmentids)], dtype='int32', compression="gzip")
+hsumgroupsegmentids[...] = sumgroupsegmentids
+
+hsumgroupidxs = f.create_dataset("hsumgroupidxs", [len(sumgroupidxs)], dtype='int32', compression="gzip")
+hsumgroupidxs[...] = sumgroupidxs
+
+hchargemetagroups = f.create_dataset("hchargemetagroups", [len(chargemetagroups)], dtype=h5py.special_dtype(vlen=str), compression="gzip")
+hchargemetagroups[...] = chargemetagroups
+
+hchargemetagroupidxs = f.create_dataset("hchargemetagroupidxs", [len(chargemetagroups),2], dtype='int32', compression="gzip")
+hchargemetagroupidxs[...] = chargemetagroupidxs
 
 hmaskedchans = f.create_dataset("hmaskedchans", [len(maskedchans)], dtype=h5py.special_dtype(vlen=str), compression="gzip")
 hmaskedchans[...] = maskedchans

--- a/scripts/text2hdf5.py
+++ b/scripts/text2hdf5.py
@@ -223,8 +223,8 @@ for chan in chans:
         sumw2_chan_hist.Delete()
       else:
         print("fallback uncertainties")
-        nentries_chan = (norm_chan_hist.GetEntries()/norm_chan_hist.GetSumOfWeights())*normchan
-        sumw2_chan = nentries_chan*np.square(normchan/nentries_chan)
+        nentries_chan = (norm_chan_hist.GetEntries()/norm_chan_hist.GetSumOfWeights())*norm_chan
+        sumw2_chan = nentries_chan*np.square(norm_chan/nentries_chan)
         nentries_chan = None
     norm_chan_hist.Delete()
     

--- a/scripts/text2hdf5.py
+++ b/scripts/text2hdf5.py
@@ -218,14 +218,14 @@ for chan in chans:
       if (norm_chan_hist.GetSumw2().GetSize()>0):
         print("proper uncertainties")
         sumw2_chan_hist = norm_chan_hist.Clone()
-        try:
-            sumw2_chan_hist.Set(sumw2_chan_hist.GetSumw2().GetSize(), sumw2_chan_hist.GetSumw2().GetArray())
-        except:
-            #in ROOT v6.12/07  set expects an array of floats not a TArrayD
+        if sumw2_chan_hist.InheritsFrom('TH1F'):
+            #work around for the fact GetSumw2 returns a TArrayD but TH1F expects a Float_t *
             from array import array
             sumw2f=[sumw2_chan_hist.GetSumw2()[i] for i in range(sumw2_chan_hist.GetSumw2().GetSize())]
             sumw2f = array('f',sumw2f)
             sumw2_chan_hist.Set(sumw2_chan_hist.GetSumw2().GetSize(), sumw2f)
+        else:
+            sumw2_chan_hist.Set(sumw2_chan_hist.GetSumw2().GetSize(), sumw2_chan_hist.GetSumw2().GetArray())
         sumw2_chan = hist2array(sumw2_chan_hist, include_overflow=False).astype(dtype)
         sumw2_chan_hist.Delete()
       else:


### PR DESCRIPTION
1) charge asymmetries (using "chargeGroup" in cards)
2) phi-integrated angular coefficients and unpolarized cross sections
(using "polGroup" in cards)
3) sum of arbitrary groups of signals (using "sumGroup" in cards)
4) charge asymmetries of sumGroups (using "chargeMetaGroup" in cards)

These are all added as additional outputs from the fit, using the same
mechanism as for the xsecs and normalized xsecs.  Note that in this
case the number of outputs is not necessarily the same as the number
of mu values (in particular when using sumGroup, but also possibly for
the others depending on how things are specified)

Currently this functionality only works for signal processes, though I
could make it work for backgrounds if really needed.

An example card for the helicity/rapidity exercising all of this is here
/afs/cern.ch/user/b/bendavid/work/cmspublic/wmucardFeb4chargeasym/Wmu_card_withXsecMask_moreoutputs.txt

This computes
1) charge asymmetries per helicity per rapidity bin,
2) unpolarized xsec, a0, a4 per charge per rapidity bin
3) total xsec per charge per rapidity bin (this is the same as the
unpolarized xsec in 2, but is needed for 4) below)
4) charge asymmetry per rapidity bin

Marco, for the differential xsecs, you should add the necessary lines
to the cards to produce
1) Charge asymmetry per eta-pT bin using chargeGroup
2) pt-integrated cross sections for each eta slice using sumGroup
3) pt-integrated charge asymmetry for each eta slice using chargeMetaGroup
