### PR TITLE
My first pull request here, with two options of combinetf.py

### DIFF
--- a/scripts/combinetf.py
+++ b/scripts/combinetf.py
@@ -3,6 +3,7 @@ import re
 from sys import argv, stdout, stderr, exit, modules
 from optparse import OptionParser
 import multiprocessing
+import os
 
 import tensorflow as tf
 
@@ -60,6 +61,8 @@ parser.add_option("","--saveHists", default=False, action='store_true', help="sa
 parser.add_option("","--computeHistErrors", default=False, action='store_true', help="propagate uncertainties to prefit and postfit histograms")
 parser.add_option("","--binByBinStat", default=False, action='store_true', help="add bin-by-bin statistical uncertainties on templates (using Barlow and Beeston 'lite' method")
 parser.add_option("","--correlateXsecStat", default=False, action='store_true', help="Assume that cross sections in masked channels are correlated with expected values in templates (ie computed from the same MC events)")
+parser.add_option("","--postfix", default="",type="string", help="add _<postfix> to output root file")
+parser.add_option("", "--outputDir", default="",type="string", help="Specify folder for output file (it is created if not existing). If SAME is given, use same folder as input file")
 (options, args) = parser.parse_args()
 
 if len(args) == 0:
@@ -504,7 +507,20 @@ if options.binByBinStat:
   bayesassignbeta = tf.assign(betagen, tf.random_gamma(shape=[],alpha=kstat+1.,beta=kstat,dtype=tf.as_dtype(dtype)))
 
 #initialize output tree
-f = ROOT.TFile( 'fitresults_%i.root' % seed, 'recreate' )
+# manage output folder                                                                                                                                                      
+outdir = ""
+if options.outputDir:
+    outdir = options.outputDir
+    if outdir == "SAME": outdir = os.path.dirname(options.fileName)
+    if not outdir.endswith('/'): outdir += "/"
+    if outdir != "./":
+        if not os.path.exists(outdir):
+            print "Creating folder", outdir
+            os.system("mkdir -p " + outdir)
+
+fname = outdir + 'fitresults_%i.root' % seed
+if options.postfix: fname = fname.replace(".root","_{pf}.root".format(pf=options.postfix))
+f = ROOT.TFile( fname , 'recreate' )
 tree = ROOT.TTree("fitresults", "fitresults")
 
 tseed = array('i', [seed])

--- a/scripts/text2hdf5.py
+++ b/scripts/text2hdf5.py
@@ -42,6 +42,8 @@ parser.add_option("-S","--doSystematics", type=int, default=1, help="enable syst
 parser.add_option("","--chunkSize", type=int, default=4*1024**2, help="chunk size for hd5fs storage")
 parser.add_option("", "--sparse", default=False, action='store_true',  help="Store normalization and systematics arrays as sparse tensors")
 parser.add_option("", "--scaleMaskedYields", type=float, default=1.,  help="Scaling factor for yields in masked channels")
+#parser.add_option("", "--postfix", default="",type="string", help="add _<postfix> to output hdf5 file")
+#parser.add_option("", "--outputDir", default="",type="string", help="Specify folder for output file (it is created if not existing)")
 (options, args) = parser.parse_args()
 
 if len(args) == 0:

--- a/scripts/text2hdf5.py
+++ b/scripts/text2hdf5.py
@@ -42,8 +42,7 @@ parser.add_option("-S","--doSystematics", type=int, default=1, help="enable syst
 parser.add_option("","--chunkSize", type=int, default=4*1024**2, help="chunk size for hd5fs storage")
 parser.add_option("", "--sparse", default=False, action='store_true',  help="Store normalization and systematics arrays as sparse tensors")
 parser.add_option("", "--scaleMaskedYields", type=float, default=1.,  help="Scaling factor for yields in masked channels")
-#parser.add_option("", "--postfix", default="",type="string", help="add _<postfix> to output hdf5 file")
-#parser.add_option("", "--outputDir", default="",type="string", help="Specify folder for output file (it is created if not existing)")
+parser.add_option("", "--postfix", default="",type="string", help="add _<postfix> to output hdf5 file")
 (options, args) = parser.parse_args()
 
 if len(args) == 0:
@@ -449,6 +448,8 @@ if chunkSize > options.chunkSize:
 outfilename = options.out.replace('.root','.hdf5')
 if options.sparse:
   outfilename = outfilename.replace('.hdf5','_sparse.hdf5')
+if options.postfix: 
+    outfilename = outfilename.replace('.hdf5','_{pf}.hdf5'.format(pf=options.postfix))
 f = h5py_cache.File(outfilename, chunk_cache_mem_size=chunkSize, mode='w')
 
 #save some lists of strings to the file for later use

--- a/scripts/text2hdf5.py
+++ b/scripts/text2hdf5.py
@@ -42,8 +42,7 @@ parser.add_option("-S","--doSystematics", type=int, default=1, help="enable syst
 parser.add_option("","--chunkSize", type=int, default=4*1024**2, help="chunk size for hd5fs storage")
 parser.add_option("", "--sparse", default=False, action='store_true',  help="Store normalization and systematics arrays as sparse tensors")
 parser.add_option("", "--scaleMaskedYields", type=float, default=1.,  help="Scaling factor for yields in masked channels")
-#parser.add_option("", "--postfix", default="",type="string", help="add _<postfix> to output hdf5 file")
-#parser.add_option("", "--outputDir", default="",type="string", help="Specify folder for output file (it is created if not existing)")
+parser.add_option("", "--postfix", default="",type="string", help="add _<postfix> to output hdf5 file")
 (options, args) = parser.parse_args()
 
 if len(args) == 0:
@@ -439,6 +438,8 @@ if chunkSize > options.chunkSize:
 outfilename = options.out.replace('.root','.hdf5')
 if options.sparse:
   outfilename = outfilename.replace('.hdf5','_sparse.hdf5')
+if options.postfix:
+    outfilename = outfilename.replace('.hdf5','_{pf}.hdf5'.format(pf=options.postfix))
 f = h5py_cache.File(outfilename, chunk_cache_mem_size=chunkSize, mode='w')
 
 #save some lists of strings to the file for later use


### PR DESCRIPTION
I openened this PR on Josh's branch, but I think it was never merged.

There are a couple of useful options for combinetf.py and text2hdf5.py

text2hdf5.py
option --postfix to add postfix to the output hdf5 file. Useful when using datacards with different configurations, without overwriting old files.

combinetf.py
option --postfi, it works as above
option --outputDir, to specifiy an output folder. This is useful to run the fit without having to move inside a specific folder (by default the current one is used). Also useful in combination with --postfix.